### PR TITLE
Replace internal property evaluations with utility function

### DIFF
--- a/apps/web/src/e2e/authenticated/comment.test.ts
+++ b/apps/web/src/e2e/authenticated/comment.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test'
 import { comments, db } from '@tszhong0411/db'
 
 import { TEST_USER } from '../constants'
+import { getNumberFlow } from '../utils/number-flow'
 
 test.describe('comment page', () => {
   test('should be able to submit a comment', async ({ page }) => {
@@ -17,16 +18,8 @@ test.describe('comment page', () => {
     await expect(page.locator('li[data-sonner-toast]')).toContainText('Comment posted')
 
     // Comment count should be updated in the blog header and comment header
-    expect(
-      // @ts-expect-error -- internal property
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-      await page.getByTestId('comment-count').evaluate((flow) => flow._internals.ariaLabel)
-    ).toBe('1')
-    expect(
-      // @ts-expect-error -- internal property
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-      await page.getByTestId('blog-comment-count').evaluate((flow) => flow._internals.ariaLabel)
-    ).toBe('1 comment')
+    expect(await getNumberFlow(page.getByTestId('comment-count'))).toBe('1')
+    expect(await getNumberFlow(page.getByTestId('blog-comment-count'))).toBe('1 comment')
   })
 
   test('should be able to delete a comment', async ({ page }) => {
@@ -53,16 +46,8 @@ test.describe('comment page', () => {
     await expect(page.locator('li[data-sonner-toast]')).toContainText('Deleted a comment')
 
     // Comment count should be updated in the blog header and comment header
-    expect(
-      // @ts-expect-error -- internal property
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-      await page.getByTestId('comment-count').evaluate((flow) => flow._internals.ariaLabel)
-    ).toBe('0')
-    expect(
-      // @ts-expect-error -- internal property
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-      await page.getByTestId('blog-comment-count').evaluate((flow) => flow._internals.ariaLabel)
-    ).toBe('0 comments')
+    expect(await getNumberFlow(page.getByTestId('comment-count'))).toBe('0')
+    expect(await getNumberFlow(page.getByTestId('blog-comment-count'))).toBe('0 comments')
   })
 
   test('should be able to reply to a comment', async ({ page }) => {
@@ -93,11 +78,7 @@ test.describe('comment page', () => {
     await expect(page.getByTestId('comments-list').getByText(replyText)).toBeVisible()
 
     // Reply count should be updated in the comment header
-    expect(
-      // @ts-expect-error -- internal property
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-      await page.getByTestId('reply-count').evaluate((flow) => flow._internals.ariaLabel)
-    ).toBe('1 reply')
+    expect(await getNumberFlow(page.getByTestId('reply-count'))).toBe('1 reply')
 
     await expect(page.locator('li[data-sonner-toast]')).toContainText('Reply posted')
   })
@@ -138,10 +119,6 @@ test.describe('comment page', () => {
     await expect(page.locator('li[data-sonner-toast]')).toContainText('Deleted a comment')
 
     // Reply count should be updated in the comment header
-    expect(
-      // @ts-expect-error -- internal property
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-      await page.getByTestId('reply-count').evaluate((flow) => flow._internals.ariaLabel)
-    ).toBe('0 replies')
+    expect(await getNumberFlow(page.getByTestId('reply-count'))).toBe('0 replies')
   })
 })

--- a/apps/web/src/e2e/unauthenticated/like-button.test.ts
+++ b/apps/web/src/e2e/unauthenticated/like-button.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test'
 
+import { getNumberFlow } from '../utils/number-flow'
+
 test.describe('like button', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/blog/test-like')
@@ -7,19 +9,13 @@ test.describe('like button', () => {
 
   test('should be able to like a post', async ({ page }) => {
     const likeCount = page.getByTestId('like-count')
-    // @ts-expect-error -- internal property
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-    expect(await likeCount.evaluate((flow) => flow._internals.ariaLabel)).toBe('0')
+    expect(await getNumberFlow(likeCount)).toBe('0')
 
     await page.getByTestId('like-button').click()
-    // @ts-expect-error -- internal property
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-    expect(await likeCount.evaluate((flow) => flow._internals.ariaLabel)).toBe('1')
+    expect(await getNumberFlow(likeCount)).toBe('1')
 
     await page.getByTestId('like-button').click()
     await page.getByTestId('like-button').click()
-    // @ts-expect-error -- internal property
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-    expect(await likeCount.evaluate((flow) => flow._internals.ariaLabel)).toBe('3')
+    expect(await getNumberFlow(likeCount)).toBe('3')
   })
 })

--- a/apps/web/src/e2e/unauthenticated/views.test.ts
+++ b/apps/web/src/e2e/unauthenticated/views.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test'
 
+import { getNumberFlow } from '../utils/number-flow'
+
 test.describe('views', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/blog/test-view')
@@ -9,10 +11,7 @@ test.describe('views', () => {
     const viewCount = page.getByTestId('view-count')
 
     await expect(async () => {
-      // @ts-expect-error -- internal property
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-      const ariaLabel = await viewCount.evaluate((flow) => flow._internals.ariaLabel)
-      expect(ariaLabel).toBe('1')
+      expect(await getNumberFlow(viewCount)).toBe('1')
     }).toPass({ timeout: 5000 })
   })
 })

--- a/apps/web/src/e2e/utils/number-flow.ts
+++ b/apps/web/src/e2e/utils/number-flow.ts
@@ -1,0 +1,10 @@
+import type { Locator } from '@playwright/test'
+
+export const getNumberFlow = async (locator: Locator) => {
+  // @ts-expect-error -- internal property
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
+  const ariaLabel = await locator.evaluate((flow) => flow._internals.ariaLabel)
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
+  return ariaLabel
+}

--- a/apps/web/src/e2e/utils/number-flow.ts
+++ b/apps/web/src/e2e/utils/number-flow.ts
@@ -3,8 +3,5 @@ import type { Locator } from '@playwright/test'
 export const getNumberFlow = async (locator: Locator) => {
   // @ts-expect-error -- internal property
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-  const ariaLabel = await locator.evaluate((flow) => flow._internals.ariaLabel)
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- internal property
-  return ariaLabel
+  return await locator.evaluate((flow) => flow._internals.ariaLabel)
 }


### PR DESCRIPTION
### Description

Reusable way to get an aria-label from the number flow component.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that doesn't fix a bug or add a feature)
- [ ] Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] `pnpm check` without any issues
- [x] I have reviewed [contributor guidelines](https://github.com/tszhong0411/honghong.me/blob/main/CONTRIBUTING.md)