### PR TITLE
Remove unused searchParams type from PageProps

### DIFF
--- a/apps/docs/src/app/(embed)/embed/page.tsx
+++ b/apps/docs/src/app/(embed)/embed/page.tsx
@@ -1,7 +1,6 @@
 import { getErrorMessage } from '@tszhong0411/utils'
 
 type PageProps = {
-  params: Promise<Record<string, string | string[] | undefined>>
   searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 

--- a/apps/web/src/app/[locale]/(admin)/layout.tsx
+++ b/apps/web/src/app/[locale]/(admin)/layout.tsx
@@ -9,7 +9,6 @@ type LayoutProps = {
   params: Promise<{
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
   children: React.ReactNode
 }
 

--- a/apps/web/src/app/[locale]/(main)/about/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/about/page.tsx
@@ -23,7 +23,6 @@ type PageProps = {
   params: Promise<{
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ locale: string }> => {

--- a/apps/web/src/app/[locale]/(main)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/blog/[slug]/page.tsx
@@ -25,7 +25,6 @@ type PageProps = {
     slug: string
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ slug: string; locale: string }> => {

--- a/apps/web/src/app/[locale]/(main)/blog/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/blog/page.tsx
@@ -14,7 +14,6 @@ type PageProps = {
   params: Promise<{
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ locale: string }> => {

--- a/apps/web/src/app/[locale]/(main)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/dashboard/page.tsx
@@ -15,7 +15,6 @@ type PageProps = {
   params: Promise<{
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ locale: string }> => {

--- a/apps/web/src/app/[locale]/(main)/guestbook/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/guestbook/page.tsx
@@ -19,7 +19,6 @@ type PageProps = {
   params: Promise<{
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ locale: string }> => {

--- a/apps/web/src/app/[locale]/(main)/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/page.tsx
@@ -25,7 +25,6 @@ type PageProps = {
   params: Promise<{
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ locale: string }> => {

--- a/apps/web/src/app/[locale]/(main)/projects/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/projects/[slug]/page.tsx
@@ -17,7 +17,6 @@ type PageProps = {
     slug: string
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ slug: string; locale: string }> => {

--- a/apps/web/src/app/[locale]/(main)/projects/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/projects/page.tsx
@@ -14,7 +14,6 @@ type PageProps = {
   params: Promise<{
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ locale: string }> => {

--- a/apps/web/src/app/[locale]/(main)/uses/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/uses/page.tsx
@@ -15,7 +15,6 @@ type PageProps = {
   params: Promise<{
     locale: string
   }>
-  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 export const generateStaticParams = (): Array<{ locale: string }> => {


### PR DESCRIPTION
Eliminate the unused `searchParams` type from `PageProps` across multiple files to streamline the codebase.